### PR TITLE
debug: re-apply qos when reconnecting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-rabbitmq-client</artifactId>
-  <version>4.4.0-SNAPSHOT</version>
+  <version>4.4.1-SNAPSHOT</version>
 
   <properties>
     <stack.version>4.4.0-SNAPSHOT</stack.version>


### PR DESCRIPTION
Check if that helps with `io.smallrye.mutiny.subscription.BackPressureFailure: Buffer full, cannot emit item`

https://github.com/smallrye/smallrye-reactive-messaging/issues/1906